### PR TITLE
Refactor base-sql to use pgp helpers

### DIFF
--- a/server/util/base-sql.js
+++ b/server/util/base-sql.js
@@ -1,55 +1,47 @@
 'use strict';
 
-const pgp = require('pg-promise');
-const _ = require('lodash');
-
 // These are functions that return the "base" queries to be passed into
 // pg-promise. The CRUD methods of the Controller will use these, though they
 // may eventually also author their own extensions or replacements.
 
-exports.create = function(table, fields) {
-  const columns = fields.map(pgp.as.name).join(',');
-  const setters = fields.map(field => `$[${field}]`).join(',');
-  const tableName = pgp.as.name(table);
-  return `INSERT INTO ${tableName} (${columns}) VALUES (${setters}) RETURNING *`;
+exports.create = function({tableName, attrs, db}) {
+  const baseQuery = db.$config.pgp.helpers.insert(attrs, null, tableName);
+  return `${baseQuery} RETURNING *`;
 };
 
-// `columns` are the columns to return
-exports.read = function(table, fields, options) {
-  options = options ? options : {};
+// `fields` are the columns to return. You can pass in an array, such as
+// ['first_name', 'last_name'],
+// or an asterisk to get everything: '*'.
+// By default, the asterisk is used.
+exports.read = function({tableName, fields, db, id}) {
+  const pgp = db.$config.pgp;
 
-  const tableName = pgp.as.name(table);
-
-  var isSingular = options.isSingular;
-  isSingular = _.isUndefined(isSingular) ? true : isSingular;
+  // Default fields to an asterisk
   fields = fields ? fields : '*';
+  var columns = pgp.as.name(fields);
 
-  var columns;
-  if (Array.isArray(fields)) {
-    columns = fields.map(pgp.as.name).join(',');
-  } else {
-    columns = fields;
+  const baseQuery = pgp.as.format(`SELECT ${columns} FROM $[tableName~]`, {
+    tableName
+  });
+
+  let endQuery;
+  if (id) {
+    endQuery = pgp.as.format('WHERE id = $[id]', {id});
   }
 
-  // Our base query
-  var query = `SELECT ${columns} FROM ${tableName}`;
-
-  // If we're looking for one, we modify the query string
-  if (isSingular) {
-    query += ' WHERE id = $[id]';
-  }
-
-  return query;
+  return `${baseQuery} ${endQuery}`;
 };
 
-exports.update = function(table, fields) {
-  const setters = fields.map(field => {
-    return `${pgp.as.name(field)}=$[${field}]`;
-  }).join(', ');
-  return `UPDATE ${pgp.as.name(table)} SET ${setters} WHERE id=$[id] RETURNING *`;
+exports.update = function({tableName, attrs, id, db}) {
+  const pgp = db.$config.pgp;
+  const baseQuery = pgp.helpers.update(attrs, null, tableName);
+  const endQuery = pgp.as.format('WHERE id=$[id] RETURNING *', {id});
+  return `${baseQuery} ${endQuery}`;
 };
 
-exports.delete = function(table) {
-  const tableName = pgp.as.name(table);
-  return `DELETE FROM ${tableName} WHERE id=$[id] RETURNING *`;
+exports.delete = function({tableName, id, db}) {
+  const pgp = db.$config.pgp;
+  return pgp.as.format('DELETE FROM $[tableName~] WHERE id=$[id] RETURNING *', {
+    tableName, id
+  });
 };


### PR DESCRIPTION
Resolves #40 

---

Previously, my system for queries involved parsing the attributes into two objects: an array of fields, and then the attributes themselves. As I move on to support meta data as well as relationships, this system was feeling a little unwieldy. This refactor should keep things tidy, as I can just pass in entire objects of columns to update.

There's also slightly less weird mapping of things now that I'm using the built-in insert/update helpers.