### PR TITLE
Switch from Bunyan to Pino; pretty print logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ process.on('unhandledRejection', (reason) => {
   const logObj = {};
 
   // Assign the `reason` to the `err` key if it is
-  // an error. This is so that Bunyan's error serializer
+  // an error. This is so that pino's error serializer
   // picks it up.
   if (reason instanceof Error) {
     logObj.err = reason;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "accepts": "1.3.3",
     "body-parser": "1.16.0",
-    "bunyan": "1.8.5",
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
     "compression": "1.6.2",
@@ -57,6 +56,7 @@
     "lodash": "4.17.4",
     "path": "0.12.7",
     "pg-promise": "5.5.6",
+    "pino": "3.3.2",
     "rc": "^1.1.6"
   },
   "devDependencies": {

--- a/server/app.js
+++ b/server/app.js
@@ -49,7 +49,7 @@ module.exports = function(options) {
   app.use(addRequestId({
     // We're using this middleware for logging purposes. Each request having
     // a unique ID can help filter many requests coming in. If we set it as a
-    // header, we'd get the benefit of Bunyan automatically logging it. But
+    // header, we'd get the benefit of Pino automatically logging it. But
     // then we'd also be sending it over the wire unnecessarily. So we turn
     // that off, which means we must remember to attach the `req.id` to all logs
     // that are sent a request. i.e.; `log.info({reqId: req.id})`

--- a/server/util/log.js
+++ b/server/util/log.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const bunyan = require('bunyan');
+const pino = require('pino');
+
+const pretty = pino.pretty();
+pretty.pipe(process.stdout);
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const isDevEnv = NODE_ENV === 'development';
@@ -11,14 +14,12 @@ function resourceSerializer(resource) {
   };
 }
 
-const log = bunyan.createLogger({
-  name: 'API-Pls',
-  serializers: bunyan.stdSerializers,
+const log = pino({
+  name: 'api-pls',
+  serializers: Object.assign({
+    resource: resourceSerializer
+  }, pino.stdSerializers),
   src: isDevEnv
-});
-
-log.addSerializers({
-  resource: resourceSerializer
-});
+}, pretty);
 
 module.exports = log;


### PR DESCRIPTION
Resolves #72 

---

This pretty prints always, which obviously isn't ideal. I'll likely need to add a new flag to toggle the environment of the server that gets started up. NODE_ENV is an obvious choice, but that one is already used so much. I might make a new, custom one, like api_env.