### PR TITLE
Update root URL to adhere to JSON API spec

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -46,16 +46,29 @@ module.exports = function(options) {
 
   router.get('/', (req, res) => res.redirect(`/v${apiVersion}`));
 
+  const links = {};
+  resources.forEach(r => {
+    links[r.resource.name] = {
+      link: r.location,
+      meta: {
+        methods: Object.keys(r.routes)
+      }
+    };
+  });
+
   // Set up the root route that describes the available endpoints.
   router.get(`/v${apiVersion}`, (req, res) => {
     sendJson(res, {
-      version: `v${apiVersion}`,
-      endpoints: resources.map(resource => {
-        return {
-          route: resource.location,
-          methods: Object.keys(resource.routes)
-        };
-      })
+      jsonapi: {
+        version: '1.0',
+        meta: {
+          extensions: []
+        }
+      },
+      meta: {
+        api_version: `${apiVersion}`,
+      },
+      links
     });
   });
 

--- a/server/resource/index.js
+++ b/server/resource/index.js
@@ -15,6 +15,7 @@ module.exports = function({resource, version, db}) {
 
   return {
     routes: routes.routes,
-    location: routes.location
+    location: routes.location,
+    resource
   };
 };


### PR DESCRIPTION
Resolves #19

Root URL response example:

```json
{
  "jsonapi": {
    "version": "1.0",
    "meta": {
      "extensions": []
    }
  },
  "meta": {
    "api_version": "1"
  },
  "links": {
    "cat": {
      "link": "/v1/cats",
      "meta": {
        "methods": [
          "post",
          "get",
          "patch",
          "delete"
        ]
      }
    },
    "category": {
      "link": "/v1/categories",
      "meta": {
        "methods": [
          "post",
          "get",
          "patch",
          "delete"
        ]
      }
    },
    "person": {
      "link": "/v1/people",
      "meta": {
        "methods": [
          "post",
          "get",
          "patch",
          "delete"
        ]
      }
    },
    "transaction": {
      "link": "/v1/transactions",
      "meta": {
        "methods": [
          "post",
          "get",
          "patch",
          "delete"
        ]
      }
    }
  }
}
```