### PR TITLE
Support disabling of CRUD actions

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const express = require('express');
 const routeBuilder = require('express-routebuilder');
 const Resource = require('./resource');
@@ -48,10 +49,15 @@ module.exports = function(options) {
 
   const links = {};
   resources.forEach(r => {
+    const allowedMethods = _.chain(r.resource.actions)
+      .pickBy()
+      .map((bool, name) => name)
+      .value();
+
     links[r.resource.name] = {
       link: r.location,
       meta: {
-        methods: Object.keys(r.routes)
+        methods: allowedMethods
       }
     };
   });

--- a/server/resource/index.js
+++ b/server/resource/index.js
@@ -7,8 +7,7 @@ module.exports = function({resource, version, db}) {
   var controller = new Controller(resource, db);
 
   var routes = new Routes({
-    pluralResourceName: resource.plural_form,
-    validations: resource.validations,
+    resource,
     controller,
     version
   });

--- a/server/resource/routes.js
+++ b/server/resource/routes.js
@@ -1,45 +1,51 @@
 'use strict';
 
 const validator = require('../util/validator');
+const serverErrors = require('../util/server-errors');
+const sendJson = require('../util/send-json');
 
-module.exports = function({version, pluralResourceName, controller, validations}) {
+module.exports = function({version, resource, controller}) {
+  const {validations, plural_form, actions} = resource;
+
+  const notAllowedMiddleware = [(req, res) => {
+    res.status(serverErrors.notAllowed.code);
+    sendJson(res, serverErrors.notAllowed.body());
+  }];
+
+  const postMiddleware = !actions.create ? notAllowedMiddleware : [
+    validator(validations.create),
+    controller.create
+  ];
+  const getManyMiddleware = !actions.readMany ? notAllowedMiddleware : [
+    validator(validations.readMany),
+    controller.read
+  ];
+  const getOneMiddleware = !actions.readOne ? notAllowedMiddleware : [
+    validator(validations.readOne),
+    controller.read
+  ];
+  const patchMiddleware = !actions.update ? notAllowedMiddleware : [
+    validator(validations.update),
+    controller.update
+  ];
+  const deleteMiddleware = !actions.delete ? notAllowedMiddleware : [
+    validator(validations.delete),
+    controller.delete
+  ];
+
   return {
     // The root location of this resource
-    location: `/v${version}/${pluralResourceName}`,
+    location: `/v${version}/${plural_form}`,
 
     // Four routes for the four CRUD ops
     routes: {
-      post: {
-        '/': [
-          validator(validations.create),
-          controller.create
-        ]
-      },
-
+      post: {'/': postMiddleware},
       get: {
-        '/': [
-          validator(validations.readMany),
-          controller.read
-        ],
-        '/:id': [
-          validator(validations.readOne),
-          controller.read
-        ]
+        '/': getOneMiddleware,
+        '/:id': getManyMiddleware
       },
-
-      patch: {
-        '/:id': [
-          validator(validations.update),
-          controller.update
-        ]
-      },
-
-      delete: {
-        '/:id': [
-          validator(validations.delete),
-          controller.delete
-        ]
-      }
+      patch: {'/:id': patchMiddleware},
+      delete: {'/:id': deleteMiddleware}
     }
   };
 };

--- a/server/util/server-errors.js
+++ b/server/util/server-errors.js
@@ -11,6 +11,16 @@ module.exports = {
     }
   },
 
+  notAllowed: {
+    code: 405,
+    body() {
+      return {
+        title: 'Method Not Allowed',
+        detail: 'This method is not permitted on this resource.'
+      };
+    }
+  },
+
   contentTypeHasParams: {
     code: 415,
     body() {

--- a/util/normalize-model/index.js
+++ b/util/normalize-model/index.js
@@ -5,7 +5,9 @@ const normalizeFields = require('./util/normalize-fields');
 const normalizeRelations = require('./util/normalize-relations');
 const normalizeBuiltInMeta = require('./util/normalize-built-in-meta');
 
-const resourceProps = ['name', 'plural_form', 'attributes', 'meta', 'relations'];
+const resourceProps = [
+  'name', 'plural_form', 'attributes', 'meta', 'relations', 'actions'
+];
 
 // Resource Models written by hand are allowed to be incomplete; for instance,
 // if you're OK with accepting a default value.
@@ -19,6 +21,13 @@ module.exports = function(resourceModel) {
       attributes: {},
       meta: {},
       relations: {},
+      actions: {
+        create: true,
+        readOne: true,
+        readMany: true,
+        update: true,
+        delete: true
+      },
       // Set the default built-in-meta
       built_in_meta_attributes: {
         created_at: true,


### PR DESCRIPTION
Users can now disable particular crud actions via the resource model:

```yaml
actions:
  create: true
  readOne: false
  readMany: true
  update: true
  delete: false
```