### PR TITLE
Definition and sql changes

### DIFF
--- a/lib/resource-definition/generate.js
+++ b/lib/resource-definition/generate.js
@@ -67,5 +67,23 @@ function generateDefinition(model) {
 // transformed slightly to be more useful to the server, and a handful of
 // computed properties goes on the Definition.
 module.exports = function(resourceModels) {
-  return _.map(resourceModels, generateDefinition);
+  const baseDefinition = _.map(resourceModels, generateDefinition);
+
+  // Now that we have all of our definitions, we can link them as necessary
+  // based on their relationships. This will help us build queries that involve
+  // relationships.
+  return _.map(baseDefinition, (definition, index, definitions) => {
+    // Find all of the resources that this resource is related to, and put them
+    // into an array.
+    const definitionsInRelationships = _.chain(definition.relationships)
+      .map((relationship) => {
+        return _.find(definitions, {name: relationship.resource});
+      })
+      // A resource may have multiple relationships with another resource. Remove
+      // duplicates from this array, since one reference is all we need here.
+      .uniq()
+      .value();
+
+    return Object.assign(definition, {definitionsInRelationships});
+  });
 };

--- a/lib/resource-model/fill-relationships.js
+++ b/lib/resource-model/fill-relationships.js
@@ -18,17 +18,33 @@ function setNonHosts(resource, key, resources) {
     // at all.
     const inverseCardinality = relationshipUtil.inverse(relation.cardinality);
     const inverseExists = _.find(related.relationships, r => {
-      return r.resource === resource.name && r.relationship === inverseCardinality;
+      return r.resource === resource.name && r.cardinality === inverseCardinality;
     });
 
     // Add in the relationship if it does not exist
     if (!inverseExists) {
+      // Ensure that the relationship array exists.
+      related.relationships = related.relationships ? related.relationships : {};
+      // Push the new relationship to the array
       related.relationships[resource.name] = {
         resource: resource.name,
         cardinality: inverseCardinality,
         host: false,
         nullable: true
       };
+    } else {
+      // This just overrides whatever the use put in.
+      inverseExists.resource = resource.name;
+      inverseExists.cardinality = inverseCardinality;
+      inverseExists.host = false;
+
+      // I need to look into whether the user really has much control over
+      // the nullability of guest relationships
+      if (!_.isUndefined(inverseExists.nullable)) {
+        inverseExists.nullable = Boolean(inverseExists.nullable);
+      } else {
+        inverseExists.nullable = true;
+      }
     }
   });
 }
@@ -39,5 +55,6 @@ function setNonHosts(resource, key, resources) {
 module.exports = function(resources) {
   const newResources = _.cloneDeep(resources);
   _.each(newResources, setNonHosts);
+
   return newResources;
 };

--- a/lib/sql/crud.js
+++ b/lib/sql/crud.js
@@ -1,8 +1,6 @@
 'use strict';
 
-// These are functions that return the "base" queries to be passed into
-// pg-promise. The CRUD methods of the Controller will use these, though they
-// may eventually also author their own extensions or replacements.
+// The functions in this file return CRUD queries to be passed into pg-promise.
 
 exports.create = function({tableName, attrs, db}) {
   const baseQuery = db.$config.pgp.helpers.insert(attrs, null, tableName);

--- a/server/resource/middleware/create.js
+++ b/server/resource/middleware/create.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const log = require('../../util/log');
-const baseSql = require('../../util/base-sql');
+const crud = require('../../../lib/sql/crud');
 const serverErrors = require('../../util/server-errors');
 const sendJson = require('../../util/send-json');
 const handleQueryError = require('../../util/handle-query-error');
@@ -48,7 +48,7 @@ module.exports = function(req, res) {
     return;
   }
 
-  const query = baseSql.create({
+  const query = crud.create({
     tableName: this.definition.name,
     db: this.db,
     attrs: columns

--- a/server/resource/middleware/delete.js
+++ b/server/resource/middleware/delete.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const log = require('../../util/log');
-const baseSql = require('../../util/base-sql');
+const crud = require('../../../lib/sql/crud');
 const handleQueryError = require('../../util/handle-query-error');
 
 module.exports = function(req, res) {
   log.info({req}, 'A delete request is being processed.');
-  const query = baseSql.delete({
+  const query = crud.delete({
     tableName: this.definition.name,
     db: this.db,
     id: req.params.id

--- a/server/resource/middleware/read.js
+++ b/server/resource/middleware/read.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const qs = require('qs');
 const log = require('../../util/log');
-const baseSql = require('../../util/base-sql');
+const crud = require('../../../lib/sql/crud');
 const serverErrors = require('../../util/server-errors');
 const sendJson = require('../../util/send-json');
 const handleQueryError = require('../../util/handle-query-error');
@@ -85,7 +85,7 @@ module.exports = function(req, res) {
 
   // `isSingular` is whether or not we're looking for 1
   // or all. This coercion is fine because SERIALs start at 1
-  const query = baseSql.read({
+  const query = crud.read({
     definition: this.definition,
     tableName: this.definition.tableName.raw,
     db: this.db,
@@ -122,7 +122,7 @@ module.exports = function(req, res) {
       }
       log.info({reqId: req.id}, 'No results returned on a paginated read many.');
 
-      const readOneAttempt = baseSql.read({
+      const readOneAttempt = crud.read({
         definition: this.definition,
         db: this.db,
         pageSize: 1,

--- a/server/resource/middleware/read.js
+++ b/server/resource/middleware/read.js
@@ -86,6 +86,7 @@ module.exports = function(req, res) {
   // `isSingular` is whether or not we're looking for 1
   // or all. This coercion is fine because SERIALs start at 1
   const query = baseSql.read({
+    definition: this.definition,
     tableName: this.definition.tableName.raw,
     db: this.db,
     fields: fieldsToReturn,
@@ -122,7 +123,7 @@ module.exports = function(req, res) {
       log.info({reqId: req.id}, 'No results returned on a paginated read many.');
 
       const readOneAttempt = baseSql.read({
-        tableName: this.definition.tableName.raw,
+        definition: this.definition,
         db: this.db,
         pageSize: 1,
         pageNumber: 1,

--- a/server/resource/middleware/update.js
+++ b/server/resource/middleware/update.js
@@ -36,7 +36,7 @@ module.exports = function(req, res) {
   // If there's nothing to update, we can use a read query.
   if (!_.size(columns)) {
     query = baseSql.read({
-      tableName: this.definition.tableName.raw,
+      definition: this.definition,
       db: this.db,
       fields: '*',
       id

--- a/server/resource/middleware/update.js
+++ b/server/resource/middleware/update.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const log = require('../../util/log');
-const baseSql = require('../../util/base-sql');
+const crud = require('../../../lib/sql/crud');
 const sendJson = require('../../util/send-json');
 const handleQueryError = require('../../util/handle-query-error');
 const formatTransaction = require('../../util/format-transaction');
@@ -35,7 +35,7 @@ module.exports = function(req, res) {
 
   // If there's nothing to update, we can use a read query.
   if (!_.size(columns)) {
-    query = baseSql.read({
+    query = crud.read({
       definition: this.definition,
       db: this.db,
       fields: '*',
@@ -45,7 +45,7 @@ module.exports = function(req, res) {
 
   // Otherwise, we get the update query.
   else {
-    query = baseSql.update({
+    query = crud.update({
       tableName: this.definition.tableName.raw,
       db: this.db,
       attrs: columns,

--- a/server/util/base-sql.js
+++ b/server/util/base-sql.js
@@ -13,7 +13,7 @@ exports.create = function({tableName, attrs, db}) {
 // ['first_name', 'last_name'],
 // or an asterisk to get everything: '*'.
 // By default, the asterisk is used.
-exports.read = function({tableName, fields, db, id, pageSize, pageNumber, enablePagination}) {
+exports.read = function({definition, fields, db, id, pageSize, pageNumber, enablePagination}) {
   const zeroIndexPageNumber = pageNumber - 1;
   const pgp = db.$config.pgp;
 
@@ -23,13 +23,10 @@ exports.read = function({tableName, fields, db, id, pageSize, pageNumber, enable
 
   let totalCountQuery = '';
   if (enablePagination) {
-    totalCountQuery = pgp.as.format(', COUNT(*) OVER () AS total_count', {
-    });
+    totalCountQuery = ', COUNT(*) OVER () AS total_count';
   }
 
-  const baseQuery = pgp.as.format(`SELECT ${columns} ${totalCountQuery} FROM $[tableName~]`, {
-    tableName
-  });
+  const baseQuery = `SELECT ${columns} ${totalCountQuery} FROM ${definition.tableName.escaped}`;
 
   let paginationQuery = '';
   if (enablePagination) {

--- a/test/fixtures/kitchen-sink/relation-guest.yaml
+++ b/test/fixtures/kitchen-sink/relation-guest.yaml
@@ -3,6 +3,12 @@ name: 'relation_guest'
 pagination:
   default_page_size: 2
 
+relationships:
+  pets:
+    resource: 'relation'
+    cardinality: 'one-to-many'
+    host: false
+
 attributes:
   first_name:
     type: 'VARCHAR(30)'

--- a/test/integration/get-one-resource/success.js
+++ b/test/integration/get-one-resource/success.js
@@ -146,7 +146,7 @@ describe('Resource GET (one) success', function() {
     });
   });
 
-  describe('when the request succeeds, with a relationship', () => {
+  describe('when the request succeeds, with a host relationship', () => {
     beforeEach((done) => {
       this.options = {
         resourcesDirectory: path.join(fixturesDirectory, 'kitchen-sink'),

--- a/test/integration/get-one-resource/success.js
+++ b/test/integration/get-one-resource/success.js
@@ -204,4 +204,63 @@ describe('Resource GET (one) success', function() {
         .end(done);
     });
   });
+
+  describe('when the request succeeds, with a guest relationship', () => {
+    beforeEach((done) => {
+      this.options = {
+        resourcesDirectory: path.join(fixturesDirectory, 'kitchen-sink'),
+        apiVersion: 2
+      };
+
+      const relationGuestSeeds = [
+        {first_name: 'sandwiches'},
+        {first_name: 'what'},
+        {first_name: 'pls'}
+      ];
+
+      const relationSeeds = [
+        {name: 'james', owner_id: '1'}
+      ];
+
+      applyMigrations(this.options)
+        .then(() => seed('relation_guest', relationGuestSeeds))
+        .then(() => seed('relation', relationSeeds))
+        .then(() => done());
+    });
+
+    it('should return a 200 OK, with the resource', (done) => {
+      const expectedData = {
+        type: 'relation_guests',
+        id: '1',
+        attributes: {
+          first_name: 'sandwiches',
+          last_name: null
+        },
+        relationships: {
+          pets: {
+            links: {
+              related: '/v2/relation_guests/1/pets'
+            }
+          },
+          one_to_one: {
+            links: {
+              related: '/v2/relation_guests/1/one_to_one'
+            }
+          }
+        }
+      };
+
+      const expectedLinks = {
+        self: '/v2/relation_guests/1'
+      };
+
+      request(app(this.options))
+        .get('/v2/relation_guests/1')
+        .expect(validators.basicValidation)
+        .expect(validators.assertData(expectedData))
+        .expect(validators.assertLinks(expectedLinks))
+        .expect(200)
+        .end(done);
+    });
+  });
 });


### PR DESCRIPTION
This is another PR in the slow march to better support the different relationship types.

- baseSql has been moved into the sql directory in lib. Now, all queries are in there except for the wipe-DB one (for now)
- definitions now have all resources that they are in relationships with attached to them for easier query buildin'