### PR TITLE
Return guest relationships

### DIFF
--- a/lib/relationship-util/index.js
+++ b/lib/relationship-util/index.js
@@ -11,18 +11,32 @@ exports.cardinality = {
 
 // `true` if the relationship could have many related entities. `false` if it's
 // just one.
-exports.isToMany = function(type) {
-  return type === exports.cardinality.manyToMany || type === exports.cardinality.oneToMany;
+exports.isToMany = function(relationship) {
+  const cardinality = relationship.cardinality;
+  return cardinality === exports.cardinality.manyToMany || cardinality === exports.cardinality.oneToMany;
+};
+
+// `true` if the relationship is hosted in the resource's own table
+exports.isStoredInOwnTable = function(relationship) {
+  if (!relationship.host) {
+    return false;
+  }
+  return relationship.cardinality !== exports.cardinality.manyToMany;
 };
 
 // `true` if the relationship is stored in a host resource table.
-exports.isStoredInHostTable = function(type) {
-  return type !== exports.cardinality.manyToMany;
+// This returns false for hosted relationships, as they are stored in the
+// resource's own table, and not a separate host table.
+exports.isStoredInHostTable = function(relationship) {
+  if (relationship.host) {
+    return false;
+  }
+  return relationship.cardinality !== exports.cardinality.manyToMany;
 };
 
 // `true` if the relationship is stored on an associative table
-exports.isStoredInAssociativeTable = function(type) {
-  return !exports.isHostedRelationship(type);
+exports.isStoredInAssociativeTable = function(relationship) {
+  return relationship.cardinality === exports.cardinality.manyToMany;
 };
 
 // Gets the inverse of a relationshipType.

--- a/lib/relationship-util/index.js
+++ b/lib/relationship-util/index.js
@@ -39,15 +39,15 @@ exports.isStoredInAssociativeTable = function(relationship) {
   return relationship.cardinality === exports.cardinality.manyToMany;
 };
 
-// Gets the inverse of a relationshipType.
+// Gets the inverse cardinality of `cardinality`.
 // "many-to-one" => "one-to-many"
 // "one-to-one" => "one-to-one"
-exports.inverse = function(relationshipType) {
-  if (relationshipType === exports.cardinality.manyToOne) {
+exports.inverse = function(cardinality) {
+  if (cardinality === exports.cardinality.manyToOne) {
     return exports.cardinality.oneToMany;
-  } else if (relationshipType === exports.cardinality.oneToMany) {
+  } else if (cardinality === exports.cardinality.oneToMany) {
     return exports.cardinality.manyToOne;
   } else {
-    return relationshipType;
+    return cardinality;
   }
 };

--- a/lib/resource-definition/generate.js
+++ b/lib/resource-definition/generate.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const sqlUtil = require('../sql/sql-util');
 const buildJsonSchema = require('./build-json-schema');
+const relationshipUtil = require('../relationship-util');
 
 // Some of the properties of the Resource Models are objects, because that
 // minimizes the typing that a human has to do. But they are more useful to us
@@ -54,6 +55,9 @@ function generateDefinition(model) {
     relationships: arrayRelationships,
     hostRelationships: _.filter(arrayRelationships, 'host'),
     guestRelationships: _.reject(arrayRelationships, 'host'),
+    relationshipsInOwnTable: _.filter(arrayRelationships, relationshipUtil.isStoredInOwnTable),
+    relationshipsInHostTable: _.filter(arrayRelationships, relationshipUtil.isStoredInHostTable),
+    relationshipsInAssociativeTable: _.filter(arrayRelationships, relationshipUtil.isStoredInAssociativeTable),
     metaNames: Object.keys(model.meta),
     meta: mapObjToArray(model.meta),
     builtInMetaNames: Object.keys(model.built_in_meta),

--- a/lib/sql/crud.js
+++ b/lib/sql/crud.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const _ = require('lodash');
+const sqlUtil = require('./sql-util');
+
 // The functions in this file return CRUD queries to be passed into pg-promise.
 
 exports.create = function({tableName, attrs, db}) {
@@ -24,7 +27,32 @@ exports.read = function({definition, fields, db, id, pageSize, pageNumber, enabl
     totalCountQuery = ', COUNT(*) OVER () AS total_count';
   }
 
-  const baseQuery = `SELECT ${columns} ${totalCountQuery} FROM ${definition.tableName.escaped}`;
+  // Add in the host tables here after the WITH's are added.
+  const tablesToPullFrom = [definition.tableName.raw];
+
+  let withClauses = '';
+  if (id) {
+    withClauses += _.map(definition.relationshipsInHostTable, relationship => {
+      // Find the related resource for this relationship
+      const related = _.find(definition.definitionsInRelationships, {name: relationship.resource});
+      // Add a virtual table to our tables to select from
+      tablesToPullFrom.push(sqlUtil.getVirtualHostTableName(relationship));
+      // Generate our with statement to create the virtual table
+      return sqlUtil.getWithStatement({
+        relatedResource: related,
+        resource: definition,
+        id,
+        relationship
+      });
+    }).join(', ');
+
+    if (withClauses) {
+      withClauses = `WITH ${withClauses}`;
+    }
+  }
+
+  const tables = pgp.as.name(tablesToPullFrom);
+  const baseQuery = `${withClauses} SELECT ${columns} ${totalCountQuery} FROM ${tables}`;
 
   let paginationQuery = '';
   if (enablePagination) {

--- a/lib/sql/sql-util.js
+++ b/lib/sql/sql-util.js
@@ -24,7 +24,7 @@ function getIdColumnFromResource(resource, options = {}) {
 // to use for that relationship.
 function getIdSuffix(relationship) {
   let idSuffix = 'id';
-  if (relationshipUtil.isToMany(relationship.cardinality)) {
+  if (relationshipUtil.isToMany(relationship)) {
     idSuffix += 's';
   }
   return idSuffix;
@@ -36,17 +36,21 @@ function getIdSuffix(relationship) {
 //
 // On the other hand, if the person-cat relationship was one-to-one, it would be
 // `pet_id`.
-function getRelationshipColumnName(relationship) {
+function getRelationshipColumnName(relationship, options = {}) {
+  const {escaped} = options;
   const idSuffix = getIdSuffix(relationship);
-  return pgp.as.name(`${relationship.name}_${idSuffix}`);
+  const rawName = `${relationship.name}_${idSuffix}`;
+  return escaped ? pgp.as.name(rawName) : rawName;
 }
 
 // This is the table name given to the result of the WITH clause when accessing
 // a host relationship in "one-to-many" or ""
-function getVirtualHostTableName(relationship) {
+function getVirtualHostTableName(relationship, options = {}) {
+  const {escaped} = options;
   const idSuffix = getIdSuffix(relationship);
   const resourceName = relationship.resource;
-  return pgp.as.name(`related_${resourceName}_${idSuffix}`);
+  const rawName = `related_${resourceName}_${idSuffix}`;
+  return escaped ? pgp.as.name(rawName) : rawName;
 }
 
 // Returns a query that aids with fetching relationship data that is stored
@@ -58,20 +62,21 @@ function getVirtualHostTableName(relationship) {
 //   `relatedResource`
 // `id`: The specific `resource` ID that is being requested.
 function getWithStatement({resource, relatedResource, relationship, id}) {
-  const hostTableName = getVirtualHostTableName(relationship);
-  const relatedTableName = getTableName(relatedResource);
-  const relatedIdColumn = getIdColumnFromResource(relatedResource);
+  const escaped = {escaped: true};
+  const hostTableName = getVirtualHostTableName(relationship, escaped);
+  const relatedTableName = getTableName(relatedResource, escaped);
+  const relatedIdColumn = getIdColumnFromResource(relatedResource, escaped);
   const hostRelationship = _.find(relatedResource.relationships, {resource: resource.name});
-  const hostColumnName = getRelationshipColumnName(hostRelationship);
+  const hostColumnName = getRelationshipColumnName(hostRelationship, escaped);
+  const guestColumnName = getRelationshipColumnName(relationship, escaped);
   const safeId = pgp.as.value(id);
 
-  return `WITH
-    ${hostTableName} AS (
+  return `${hostTableName} AS (
       SELECT array(
         SELECT ${relatedIdColumn}
           FROM ${relatedTableName}
           WHERE ${hostColumnName}=${safeId}
-      ) AS ${hostColumnName}
+      ) AS ${guestColumnName}
     )`;
 }
 

--- a/test/integration/get-many-resource/success.js
+++ b/test/integration/get-many-resource/success.js
@@ -435,7 +435,7 @@ describe('Resource GET (many)', function() {
     });
   });
 
-  describe('when the request succeeds, with a relationship', () => {
+  describe('when the request succeeds, with a host relationship', () => {
     beforeEach((done) => {
       this.options = {
         resourcesDirectory: path.join(fixturesDirectory, 'kitchen-sink'),

--- a/test/integration/get-one-resource/success.js
+++ b/test/integration/get-one-resource/success.js
@@ -219,7 +219,11 @@ describe('Resource GET (one) success', function() {
       ];
 
       const relationSeeds = [
-        {name: 'james', owner_id: '1'}
+        {name: 'james', owner_id: '1'},
+        {name: 'hungry', owner_id: '3'},
+        {name: 'pizza', owner_id: '1'},
+        {name: 'sammy', owner_id: '2'},
+        {name: 'meow', owner_id: '1'},
       ];
 
       applyMigrations(this.options)
@@ -228,7 +232,7 @@ describe('Resource GET (one) success', function() {
         .then(() => done());
     });
 
-    it('should return a 200 OK, with the resource', (done) => {
+    it('should return a 200 OK, with the resource and its related items', (done) => {
       const expectedData = {
         type: 'relation_guests',
         id: '1',
@@ -238,7 +242,13 @@ describe('Resource GET (one) success', function() {
         },
         relationships: {
           pets: {
+            data: [
+              {id: '1', type: 'relation'},
+              {id: '3', type: 'relation'},
+              {id: '5', type: 'relation'},
+            ],
             links: {
+              self: '/v2/relation_guests/1/relationships/pets',
               related: '/v2/relation_guests/1/pets'
             }
           },
@@ -251,7 +261,7 @@ describe('Resource GET (one) success', function() {
       };
 
       const expectedLinks = {
-        self: '/v2/relation_guests/1'
+        self: '/v2/relation_guests/1',
       };
 
       request(app(this.options))

--- a/test/unit/lib/sql/sql-util.js
+++ b/test/unit/lib/sql/sql-util.js
@@ -51,13 +51,21 @@ describe('sqlUtil', function() {
 
   describe('getRelationshipColumnName', () => {
     it('should return the right column name', () => {
-      assert.equal(sqlUtil.getRelationshipColumnName(this.oneToManyRelationship), '"owner_ids"');
+      assert.equal(sqlUtil.getRelationshipColumnName(this.oneToManyRelationship), 'owner_ids');
+    });
+
+    it('should return the right escaped column name', () => {
+      assert.equal(sqlUtil.getRelationshipColumnName(this.oneToManyRelationship, {escaped: true}), '"owner_ids"');
     });
   });
 
   describe('getVirtualHostTableName', () => {
     it('should return the right temporary table name', () => {
-      assert.equal(sqlUtil.getVirtualHostTableName(this.oneToManyRelationship), '"related_person_ids"');
+      assert.equal(sqlUtil.getVirtualHostTableName(this.oneToManyRelationship), 'related_person_ids');
+    });
+
+    it('should return the right escaped temporary table name', () => {
+      assert.equal(sqlUtil.getVirtualHostTableName(this.oneToManyRelationship, {escaped: true}), '"related_person_ids"');
     });
   });
 });


### PR DESCRIPTION
This code is very messy, but it works. So that's a good start. This begins the process of returning guest relationships. What are guest relationships? Those are relationships that are stored in the database as foreign keys in _another_ table. For instance, if a cat has a foreign key to a person, then the "guest relationship" that this supports is retrieving the person and getting all of the cats.

This also paves the path to supporting the last type of relationship: those stored in associative tables (many to many).

---

Todo:

- [ ] Support guest relationships in read many. This may require updating the query to line up the columns?
- [ ] Organize integration tests around the different relationship types. Everything should be isolated; tests shouldn't reuse the same resource types.
- [ ] test one-to-one

There's probably more, too.