### PR TITLE
Fix relationship links returned

### DIFF
--- a/server/util/build-response-relationships.js
+++ b/server/util/build-response-relationships.js
@@ -9,14 +9,14 @@ function formatToOneResult({result, definition, value, version, columnBase, rela
   const id = value ? String(value) : null;
   const relatedObject = {
     links: {
-      related: `/v${version}/${definition.plural_form}/${result.id}/${columnBase}`
+      self: `/v${version}/${definition.plural_form}/${result.id}/relationships/${columnBase}`
     }
   };
 
   // If something is associated, then we can add more information.
   if (id) {
     const pluralRelated = adjustResourceQuantity.getPluralName(relation.resource);
-    relatedObject.links.self = `/v${version}/${pluralRelated}/${id}`;
+    relatedObject.links.related = `/v${version}/${definition.plural_form}/${result.id}/${columnBase}`;
     relatedObject.data = {
       type: pluralRelated,
       id

--- a/test/integration/get-many-resource/success.js
+++ b/test/integration/get-many-resource/success.js
@@ -476,7 +476,7 @@ describe('Resource GET (many)', function() {
                 type: 'relation_guests'
               },
               links: {
-                self: '/v5/relation_guests/1',
+                self: '/v5/relations/1/relationships/owner',
                 related: '/v5/relations/1/owner'
               }
             }
@@ -496,7 +496,7 @@ describe('Resource GET (many)', function() {
                 type: 'relation_guests'
               },
               links: {
-                self: '/v5/relation_guests/3',
+                self: '/v5/relations/2/relationships/owner',
                 related: '/v5/relations/2/owner'
               }
             }
@@ -512,7 +512,7 @@ describe('Resource GET (many)', function() {
           relationships: {
             owner: {
               links: {
-                related: '/v5/relations/3/owner'
+                self: '/v5/relations/3/relationships/owner'
               }
             }
           }

--- a/test/integration/get-one-resource/success.js
+++ b/test/integration/get-one-resource/success.js
@@ -185,7 +185,7 @@ describe('Resource GET (one) success', function() {
             },
             links: {
               related: '/v2/relations/1/owner',
-              self: '/v2/relation_guests/1'
+              self: '/v2/relations/1/relationships/owner'
             }
           }
         }
@@ -254,7 +254,7 @@ describe('Resource GET (one) success', function() {
           },
           one_to_one: {
             links: {
-              related: '/v2/relation_guests/1/one_to_one'
+              self: '/v2/relation_guests/1/relationships/one_to_one'
             }
           }
         }

--- a/test/integration/patch-resource/success.js
+++ b/test/integration/patch-resource/success.js
@@ -214,7 +214,7 @@ describe('Resource PATCH success', function() {
               type: 'relation_guests'
             },
             links: {
-              self: '/v24/relation_guests/3',
+              self: '/v24/relations/1/relationships/owner',
               related: '/v24/relations/1/owner'
             }
           }

--- a/test/integration/post-resource/success.js
+++ b/test/integration/post-resource/success.js
@@ -146,7 +146,7 @@ describe('Resource POST success', function() {
               type: 'relation_guests'
             },
             links: {
-              self: '/v10/relation_guests/1',
+              self: '/v10/relations/1/relationships/owner',
               related: '/v10/relations/1/owner'
             }
           }
@@ -215,7 +215,7 @@ describe('Resource POST success', function() {
               type: 'relation_guests'
             },
             links: {
-              self: '/v10/relation_guests/1',
+              self: '/v10/one_to_ones/1/relationships/owner',
               related: '/v10/one_to_ones/1/owner'
             }
           }


### PR DESCRIPTION
This needed to come before #15. Now, the right links are returned from the endpoints.

`self`: this references the relationship itself. Accordingly, it can be CRUD'd.
`related`: this only exists when the relationship has a non-null value. It references a URL that you can GET to retrieve the related resource(s).