### PR TITLE
Fix error in relationship response builder

### DIFF
--- a/server/util/build-response-relationships.js
+++ b/server/util/build-response-relationships.js
@@ -28,7 +28,7 @@ function formatToOneResult({result, definition, value, version, columnBase, rela
 
 function formatToManyResult({result, definition, value, version, columnBase, relation}) {
   // Ensure that all of the IDs are strings.
-  const ids = value.map(id => String(id));
+  const ids = _.map(value, id => String(id));
 
   const relatedObject = {
     links: {


### PR DESCRIPTION
Another good reason to always stick to the Lodash methods. Sometimes, `value` was null, causing this to throw.

My integration tests didn't catch this since I'm pretty light on the relationship tests right now. #201 should help with that.