### PR TITLE
Add one-to-one fixtures; convert POST to use them

### DIFF
--- a/test/fixtures/one-to-one/chip.yml
+++ b/test/fixtures/one-to-one/chip.yml
@@ -1,0 +1,14 @@
+name: 'chip'
+
+relationships:
+  host:
+    resource: 'dog'
+    cardinality: 'one-to-one'
+    host: false
+
+attributes:
+  type: 'VARCHAR(30)'
+
+built_in_meta:
+  created_at: false
+  updated_at: false

--- a/test/fixtures/one-to-one/dog.yml
+++ b/test/fixtures/one-to-one/dog.yml
@@ -1,0 +1,14 @@
+name: 'dog'
+
+relationships:
+  device:
+    resource: 'chip'
+    cardinality: 'one-to-one'
+
+attributes:
+  name: 'VARCHAR(30)'
+  size: 'VARCHAR(30)'
+
+built_in_meta:
+  created_at: false
+  updated_at: false

--- a/test/integration/post-resource/failure.js
+++ b/test/integration/post-resource/failure.js
@@ -350,22 +350,22 @@ describe('Resource POST failure', function() {
   describe('when the request violates a one-to-one relationship', () => {
     beforeEach((done) => {
       this.options = {
-        resourcesDirectory: path.join(fixturesDirectory, 'kitchen-sink'),
+        resourcesDirectory: path.join(fixturesDirectory, 'one-to-one'),
         apiVersion: 10
       };
 
-      const relationGuestSeeds = [{
-        first_name: 'sandwiches'
+      const chipSeeds = [{
+        type: 'fancy'
       }];
 
-      const oneToOneSeeds = [{
+      const dogSeeds = [{
         name: 'ok',
-        owner_id: '1'
+        device_id: '1'
       }];
 
       applyMigrations(this.options)
-      .then(() => seed('relation_guest', relationGuestSeeds))
-        .then(() => seed('one_to_one', oneToOneSeeds))
+      .then(() => seed('chip', chipSeeds))
+        .then(() => seed('dog', dogSeeds))
         .then(() => done());
     });
 
@@ -376,22 +376,22 @@ describe('Resource POST failure', function() {
       }];
 
       const expectedLinks = {
-        self: '/v10/one_to_ones'
+        self: '/v10/dogs'
       };
 
       request(app(this.options))
-        .post('/v10/one_to_ones')
+        .post('/v10/dogs')
         .send({
           data: {
-            type: 'one_to_ones',
+            type: 'dogs',
             attributes: {
               name: 'please'
             },
             relationships: {
-              owner: {
+              device: {
                 data: {
                   id: '1',
-                  type: 'relation_guests'
+                  type: 'chips'
                 }
               }
             }


### PR DESCRIPTION
Part of #201 involves organizing the integration tests around relationships. This is one small step toward that.

Basically, I was just throwing random properties onto things in the kitchen sink, and it made it harder to keep track of what was actually being tested. I'm going to:

1. build special fixtures just for relationships
2. create special files just for testing relationships

This is migrating an existing test to using the new for-this-purpose fixture.