### PR TITLE
Support reads of m-n relationships

### DIFF
--- a/lib/resource-definition/generate.js
+++ b/lib/resource-definition/generate.js
@@ -65,6 +65,7 @@ function generateDefinition(model) {
     // These relationships are stored as foreign keys in _another_ resource's
     // table
     relationshipsInHostTable: _.filter(arrayRelationships, relationshipUtil.isStoredInHostTable),
+    externallyStoredRelationships: _.reject(arrayRelationships, relationshipUtil.isStoredInOwnTable),
     // These are relationships that exist in an associative table
     relationshipsInAssociativeTable: _.filter(arrayRelationships, relationshipUtil.isStoredInAssociativeTable),
     // These are the associative table relationships that this resource hosts

--- a/lib/sql/build-single-migration.js
+++ b/lib/sql/build-single-migration.js
@@ -2,8 +2,8 @@
 
 const _ = require('lodash');
 const pgp = require('pg-promise');
-const sqlUtil = require('./sql-util');
 const manyToManyUtil = require('./many-to-many-util');
+const sqlUtil = require('./sql-util');
 
 function generateIdColumn(definition) {
   const idColumn = sqlUtil.getIdColumnFromResource(definition, {escaped: true});

--- a/lib/sql/crud.js
+++ b/lib/sql/crud.js
@@ -2,7 +2,9 @@
 
 const _ = require('lodash');
 const sqlUtil = require('./sql-util');
+const manyToManyUtil = require('./many-to-many-util');
 const withStatement = require('./with-statement');
+const relationshipUtil = require('../relationship-util');
 
 // The functions in this file return CRUD queries to be passed into pg-promise.
 
@@ -37,8 +39,19 @@ exports.read = function({definition, fields, db, id, pageSize, pageNumber, enabl
     const selfTableName = sqlUtil.getTableName(definition, escaped);
     const selfIdColumnName = sqlUtil.getIdColumnFromResource(definition, escaped);
     const virtualTableName = sqlUtil.getVirtualHostTableName(relationship, escaped);
-    const otherForeignKeyColumn = sqlUtil.getRelationshipColumnName(otherRelationship, escaped);
-    const selfForeignKeyColumn = sqlUtil.getRelationshipColumnName(relationship, escaped);
+
+    let otherForeignKeyColumn, selfForeignKeyColumn;
+    if (!relationshipUtil.isStoredInAssociativeTable(relationship)) {
+      otherForeignKeyColumn = sqlUtil.getRelationshipColumnName(otherRelationship, escaped);
+      selfForeignKeyColumn = sqlUtil.getRelationshipColumnName(relationship, escaped);
+    } else if (!relationship.host) {
+      selfForeignKeyColumn = manyToManyUtil.getHostIdColumnName({host: otherResource, escaped: true});
+      otherForeignKeyColumn = manyToManyUtil.getGuestIdColumnName({guest: definition, escaped: true});
+    } else {
+      selfForeignKeyColumn = manyToManyUtil.getGuestIdColumnName({guest: otherResource, escaped: true});
+      otherForeignKeyColumn = manyToManyUtil.getHostIdColumnName({host: definition, escaped: true});
+    }
+
     if (id) {
       columns += `, (SELECT ${selfForeignKeyColumn} FROM ${virtualTableName}) AS ${selfForeignKeyColumn}`;
     } else {

--- a/lib/sql/crud.js
+++ b/lib/sql/crud.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const sqlUtil = require('./sql-util');
+const withStatement = require('./with-statement');
 
 // The functions in this file return CRUD queries to be passed into pg-promise.
 
@@ -29,7 +30,7 @@ exports.read = function({definition, fields, db, id, pageSize, pageNumber, enabl
   }
 
   const escaped = {escaped: true};
-  let withClauses = _.map(definition.relationshipsInHostTable, relationship => {
+  let withClauses = _.map(definition.guestRelationships, relationship => {
     const hostResource = _.find(definition.definitionsInRelationships, {name: relationship.resource});
     const hostRelationship = _.find(hostResource.relationships, {resource: definition.name});
 
@@ -48,7 +49,7 @@ exports.read = function({definition, fields, db, id, pageSize, pageNumber, enabl
 
     // Find the related resource for this relationship
     // Generate our with statement to create the virtual table
-    return sqlUtil.getWithStatement({
+    return withStatement({
       resource: definition,
       hostResource, id, relationship
     });

--- a/lib/sql/crud.js
+++ b/lib/sql/crud.js
@@ -30,29 +30,31 @@ exports.read = function({definition, fields, db, id, pageSize, pageNumber, enabl
   }
 
   const escaped = {escaped: true};
-  let withClauses = _.map(definition.guestRelationships, relationship => {
-    const hostResource = _.find(definition.definitionsInRelationships, {name: relationship.resource});
-    const hostRelationship = _.find(hostResource.relationships, {resource: definition.name});
+  let withClauses = _.map(definition.externallyStoredRelationships, relationship => {
+    const otherResource = _.find(definition.definitionsInRelationships, {name: relationship.resource});
+    const otherRelationship = _.find(otherResource.relationships, {resource: definition.name});
 
-    const guestTableName = sqlUtil.getTableName(definition, escaped);
-    const guestIdColumnName = sqlUtil.getIdColumnFromResource(definition, escaped);
+    const selfTableName = sqlUtil.getTableName(definition, escaped);
+    const selfIdColumnName = sqlUtil.getIdColumnFromResource(definition, escaped);
     const virtualTableName = sqlUtil.getVirtualHostTableName(relationship, escaped);
-    const foreignKeyColumn = sqlUtil.getRelationshipColumnName(hostRelationship, escaped);
-    const guestForeignKeyColumn = sqlUtil.getRelationshipColumnName(relationship, escaped);
+    const otherForeignKeyColumn = sqlUtil.getRelationshipColumnName(otherRelationship, escaped);
+    const selfForeignKeyColumn = sqlUtil.getRelationshipColumnName(relationship, escaped);
     if (id) {
-      columns += `, (SELECT ${guestForeignKeyColumn} FROM ${virtualTableName}) AS ${guestForeignKeyColumn}`;
+      columns += `, (SELECT ${selfForeignKeyColumn} FROM ${virtualTableName}) AS ${selfForeignKeyColumn}`;
     } else {
       columns += `, (SELECT
-        ${guestForeignKeyColumn} FROM ${virtualTableName}
-        WHERE ${guestTableName}.${guestIdColumnName} = ${virtualTableName}.${foreignKeyColumn}) AS ${guestForeignKeyColumn}`;
+        ${selfForeignKeyColumn} FROM ${virtualTableName}
+        WHERE ${selfTableName}.${selfIdColumnName} = ${virtualTableName}.${otherForeignKeyColumn}) AS ${selfForeignKeyColumn}`;
     }
 
     // Find the related resource for this relationship
     // Generate our with statement to create the virtual table
-    return withStatement({
+    const withIt = withStatement({
       resource: definition,
-      hostResource, id, relationship
+      otherResource, id, relationship
     });
+
+    return withIt;
   }).join(', ');
 
   if (withClauses) {

--- a/lib/sql/sql-util.js
+++ b/lib/sql/sql-util.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const pgp = require('pg-promise');
 const relationshipUtil = require('../relationship-util');
 
@@ -53,39 +52,7 @@ function getVirtualHostTableName(relationship, options = {}) {
   return escaped ? pgp.as.name(rawName) : rawName;
 }
 
-// Returns a query that aids with fetching relationship data that is stored
-// in a host table (one-to-many and one-to-one relationships).
-//
-// `resource`: The resource that is being requested
-// `hostResource`: the host of the relationship
-// `relationship`: The "guest" relationship; the one on `resource` referring to
-//   `hostResource`
-// `id`: The specific `resource` ID that is being requested.
-function getWithStatement({resource, hostResource, relationship, id}) {
-  const escaped = {escaped: true};
-  const virtualTableName = getVirtualHostTableName(relationship, escaped);
-  const hostTableName = getTableName(hostResource, escaped);
-  const relatedIdColumn = getIdColumnFromResource(hostResource, escaped);
-  const hostRelationship = _.find(hostResource.relationships, {resource: resource.name});
-  const foreignKeyColumn = getRelationshipColumnName(hostRelationship, escaped);
-  // Of course, the notion of a "guest foreign key" doesn't really exist. But
-  // that is effectively what this value is representing.
-  const guestForeignKeyColumn = getRelationshipColumnName(relationship, escaped);
-
-  // Filter by the ID if this is singular
-  const whereStatement = id ? `WHERE ${foreignKeyColumn}=${pgp.as.value(id)}` : '';
-
-  return `${virtualTableName} AS (
-    SELECT
-      ${foreignKeyColumn},
-      array_agg(${relatedIdColumn}) AS ${guestForeignKeyColumn}
-    FROM ${hostTableName}
-    ${whereStatement}
-    GROUP BY ${foreignKeyColumn}
-  )`;
-}
-
 module.exports = {
   getTableName, getIdColumnFromResource, getIdSuffix, getRelationshipColumnName,
-  getVirtualHostTableName, getWithStatement
+  getVirtualHostTableName
 };

--- a/lib/sql/with-statement.js
+++ b/lib/sql/with-statement.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const _ = require('lodash');
+const pgp = require('pg-promise');
+const relationshipUtil = require('../relationship-util');
+const manyToManyUtil = require('./many-to-many-util');
+const sqlUtil = require('./sql-util');
+
+// Returns a query that aids with fetching relationship data that is stored
+// in a host table (one-to-many and one-to-one relationships).
+//
+// `resource`: The resource that is being requested
+// `hostResource`: the host of the relationship
+// `relationship`: The "guest" relationship; the one on `resource` referring to
+//   `hostResource`
+// `id`: The specific `resource` ID that is being requested.
+module.exports = function({resource, hostResource, relationship, id}) {
+  const isManyToMany = relationship.cardinality === relationshipUtil.cardinality.manyToMany;
+  const escaped = {escaped: true};
+  const virtualTableName = sqlUtil.getVirtualHostTableName(relationship, escaped);
+
+  let hostTableName;
+  if (!isManyToMany) {
+    hostTableName = sqlUtil.getTableName(hostResource, escaped);
+  } else {
+    hostTableName = manyToManyUtil.getAssociativeTableName({
+      guest: resource,
+      host: hostResource,
+      escaped: true
+    });
+  }
+
+  let relatedIdColumn;
+  if (!isManyToMany) {
+    relatedIdColumn = sqlUtil.getIdColumnFromResource(hostResource, escaped);
+  } else {
+    relatedIdColumn = manyToManyUtil.getHostIdColumnName({host: hostResource, escaped: true});
+  }
+
+  const hostRelationship = _.find(hostResource.relationships, {resource: resource.name});
+
+  let foreignKeyColumn;
+  if (!isManyToMany) {
+    foreignKeyColumn = sqlUtil.getRelationshipColumnName(hostRelationship, escaped);
+  } else {
+    foreignKeyColumn = manyToManyUtil.getGuestIdColumnName({guest: resource, escaped: true});
+  }
+  // Of course, the notion of a "guest foreign key" doesn't really exist. But
+  // that is effectively what this value is representing.
+
+  const guestForeignKeyColumn = sqlUtil.getRelationshipColumnName(relationship, escaped);
+
+  // Filter by the ID if this is singular
+  const whereStatement = id ? `WHERE ${foreignKeyColumn}=${pgp.as.value(id)}` : '';
+
+  return `${virtualTableName} AS (
+    SELECT
+      ${foreignKeyColumn},
+      array_agg(${relatedIdColumn}) AS ${guestForeignKeyColumn}
+    FROM ${hostTableName}
+    ${whereStatement}
+    GROUP BY ${foreignKeyColumn}
+  )`;
+};

--- a/lib/sql/with-statement.js
+++ b/lib/sql/with-statement.js
@@ -10,44 +10,57 @@ const sqlUtil = require('./sql-util');
 // in a host table (one-to-many and one-to-one relationships).
 //
 // `resource`: The resource that is being requested
-// `hostResource`: the host of the relationship
+// `otherResource`: the host of the relationship
 // `relationship`: The "guest" relationship; the one on `resource` referring to
-//   `hostResource`
+//   `otherResource`
 // `id`: The specific `resource` ID that is being requested.
-module.exports = function({resource, hostResource, relationship, id}) {
+module.exports = function({resource, otherResource, relationship, id}) {
   const isManyToMany = relationship.cardinality === relationshipUtil.cardinality.manyToMany;
   const escaped = {escaped: true};
   const virtualTableName = sqlUtil.getVirtualHostTableName(relationship, escaped);
+  const isHost = relationship.host;
+
+  let guest, host;
+  if (relationship.host) {
+    host = resource;
+    guest = otherResource;
+  } else {
+    guest = resource;
+    host = otherResource;
+  }
 
   let hostTableName;
   if (!isManyToMany) {
-    hostTableName = sqlUtil.getTableName(hostResource, escaped);
+    hostTableName = sqlUtil.getTableName(otherResource, escaped);
   } else {
     hostTableName = manyToManyUtil.getAssociativeTableName({
-      guest: resource,
-      host: hostResource,
+      guest, host,
       escaped: true
     });
   }
 
   let relatedIdColumn;
   if (!isManyToMany) {
-    relatedIdColumn = sqlUtil.getIdColumnFromResource(hostResource, escaped);
+    relatedIdColumn = sqlUtil.getIdColumnFromResource(otherResource, escaped);
+  } else if (!isHost) {
+    relatedIdColumn = manyToManyUtil.getHostIdColumnName({host, escaped: true});
   } else {
-    relatedIdColumn = manyToManyUtil.getHostIdColumnName({host: hostResource, escaped: true});
+    relatedIdColumn = manyToManyUtil.getGuestIdColumnName({guest, escaped: true});
   }
 
-  const hostRelationship = _.find(hostResource.relationships, {resource: resource.name});
+  const hostRelationship = _.find(otherResource.relationships, {resource: resource.name});
 
   let foreignKeyColumn;
   if (!isManyToMany) {
     foreignKeyColumn = sqlUtil.getRelationshipColumnName(hostRelationship, escaped);
+  } else if (!isHost) {
+    foreignKeyColumn = manyToManyUtil.getGuestIdColumnName({guest, escaped: true});
   } else {
-    foreignKeyColumn = manyToManyUtil.getGuestIdColumnName({guest: resource, escaped: true});
+    foreignKeyColumn = manyToManyUtil.getHostIdColumnName({host, escaped: true});
   }
+
   // Of course, the notion of a "guest foreign key" doesn't really exist. But
   // that is effectively what this value is representing.
-
   const guestForeignKeyColumn = sqlUtil.getRelationshipColumnName(relationship, escaped);
 
   // Filter by the ID if this is singular

--- a/lib/sql/with-statement.js
+++ b/lib/sql/with-statement.js
@@ -61,7 +61,14 @@ module.exports = function({resource, otherResource, relationship, id}) {
 
   // Of course, the notion of a "guest foreign key" doesn't really exist. But
   // that is effectively what this value is representing.
-  const guestForeignKeyColumn = sqlUtil.getRelationshipColumnName(relationship, escaped);
+  let guestForeignKeyColumn;
+  if (!isManyToMany) {
+    guestForeignKeyColumn = sqlUtil.getRelationshipColumnName(relationship, escaped);
+  } else if (isHost) {
+    guestForeignKeyColumn = manyToManyUtil.getGuestIdColumnName({guest: otherResource, escaped: true});
+  } else {
+    guestForeignKeyColumn = manyToManyUtil.getHostIdColumnName({host: otherResource, escaped: true});
+  }
 
   // Filter by the ID if this is singular
   const whereStatement = id ? `WHERE ${foreignKeyColumn}=${pgp.as.value(id)}` : '';

--- a/lib/sql/with-statement.js
+++ b/lib/sql/with-statement.js
@@ -7,13 +7,14 @@ const manyToManyUtil = require('./many-to-many-util');
 const sqlUtil = require('./sql-util');
 
 // Returns a query that aids with fetching relationship data that is stored
-// in a host table (one-to-many and one-to-one relationships).
+// in an external table. This may be a foreign key in a host resource's table
+// or an associative table for m-n relationships.
 //
 // `resource`: The resource that is being requested
-// `otherResource`: the host of the relationship
-// `relationship`: The "guest" relationship; the one on `resource` referring to
+// `otherResource`: the other resource in the relationship
+// `relationship`: The relationship at hand; the one on `resource` referring to
 //   `otherResource`
-// `id`: The specific `resource` ID that is being requested.
+// `id`: The specific `resource` ID that is being requested. Optional.
 module.exports = function({resource, otherResource, relationship, id}) {
   const isManyToMany = relationship.cardinality === relationshipUtil.cardinality.manyToMany;
   const escaped = {escaped: true};

--- a/server/util/build-response-relationships.js
+++ b/server/util/build-response-relationships.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const adjustResourceQuantity = require('./adjust-resource-quantity');
 const sqlUtil = require('../../lib/sql/sql-util');
-// const manyToManyUtil = require('../../lib/sql/many-to-many-util');
+const manyToManyUtil = require('../../lib/sql/many-to-many-util');
 const relationshipUtil = require('../../lib/relationship-util');
 
 function formatToOneResult({result, definition, value, version, columnBase, relation}) {
@@ -80,9 +80,14 @@ function findHostedRelationships(result, definition, version) {
 
 function findAssociatedRelationships(result, definition, version) {
   return _.reduce(definition.relationshipsInAssociativeTable, (memo, relation) => {
-    // const hostResource = _.find(definition.definitionsInRelationships, {name: relationship.resource});
+    const otherResource = _.find(definition.definitionsInRelationships, {name: relation.resource});
     const columnBase = adjustResourceQuantity.getPluralName(relation.resource);
-    const columnName = sqlUtil.getRelationshipColumnName(relation);
+    let columnName;
+    if (!relation.host) {
+      columnName = manyToManyUtil.getHostIdColumnName({host: otherResource});
+    } else {
+      columnName = manyToManyUtil.getGuestIdColumnName({guest: otherResource});
+    }
     const value = result[columnName];
 
     const isToMany = relationshipUtil.isToMany(relation);

--- a/test/integration/get-many-resource/many-to-many/guest.js
+++ b/test/integration/get-many-resource/many-to-many/guest.js
@@ -1,0 +1,140 @@
+const path = require('path');
+const request = require('supertest');
+const app = require('../../../../server/app');
+const getDb = require('../../../../lib/database');
+const wipeDatabase = require('../../../../lib/database/wipe');
+const validators = require('../../../helpers/json-api-validators');
+const applyMigrations = require('../../../helpers/apply-migrations');
+const seed = require('../../../helpers/seed');
+
+const db = getDb();
+
+describe('Resource GET (many) many-to-many (guest)', function() {
+  // Ensure that the DB connection drops immediately after each test
+  afterEach(() => {
+    db.$config.pgp.end();
+  });
+
+  // Ensure that there's no lingering data between tests by wiping the
+  // database before each test.
+  beforeEach(done => {
+    wipeDatabase(db).then(() => done());
+  });
+
+  describe('when the request succeeds', () => {
+    beforeEach((done) => {
+      this.options = {
+        resourcesDirectory: path.join(global.fixturesDirectory, 'many-to-many'),
+        apiVersion: 2
+      };
+
+      const toppingSeeds = [
+        {name: 'cheese'},
+        {name: 'marinara'},
+        {name: 'pepperoni'}
+      ];
+
+      const pizzaSeeds = [
+        {name: 'cheese', size: 'small'},
+        {name: 'pepperoni', size: '3'},
+        {name: 'white', size: '1'}
+      ];
+
+      const pizzaToppingSeeds = [
+        // Cheese pizza: cheese, marinara
+        {pizza_id: '1', topping_id: '1'},
+        {pizza_id: '1', topping_id: '2'},
+        // pepperoni pizza: cheese, marinara, pepperoni
+        {pizza_id: '2', topping_id: '1'},
+        {pizza_id: '2', topping_id: '2'},
+        {pizza_id: '2', topping_id: '3'},
+        // white pizza: cheese
+        {pizza_id: '3', topping_id: '1'},
+      ];
+
+      applyMigrations(this.options)
+        .then(() => seed('topping', toppingSeeds))
+        .then(() => seed('pizza', pizzaSeeds))
+        .then(() => seed('pizza_topping', pizzaToppingSeeds))
+        .then(() => done());
+    });
+
+    it('should return a 200 OK, with the resource and its related items', (done) => {
+      const expectedData = [
+        {
+          type: 'toppings',
+          id: '1',
+          attributes: {
+            name: 'cheese'
+          },
+          relationships: {
+            pizzas: {
+              data: [
+                {id: '1', type: 'pizzas'},
+                {id: '2', type: 'pizzas'},
+                {id: '3', type: 'pizzas'},
+              ],
+              links: {
+                self: '/v2/toppings/1/relationships/pizzas',
+                related: '/v2/toppings/1/pizzas'
+              }
+            }
+          }
+        },
+        {
+          type: 'toppings',
+          id: '2',
+          attributes: {
+            name: 'marinara'
+          },
+          relationships: {
+            pizzas: {
+              data: [
+                {id: '1', type: 'pizzas'},
+                {id: '2', type: 'pizzas'},
+              ],
+              links: {
+                self: '/v2/toppings/2/relationships/pizzas',
+                related: '/v2/toppings/2/pizzas'
+              }
+            }
+          }
+        },
+        {
+          type: 'toppings',
+          id: '3',
+          attributes: {
+            name: 'pepperoni'
+          },
+          relationships: {
+            pizzas: {
+              data: [
+                {id: '2', type: 'pizzas'},
+              ],
+              links: {
+                self: '/v2/toppings/3/relationships/pizzas',
+                related: '/v2/toppings/3/pizzas'
+              }
+            }
+          }
+        }
+      ];
+
+      const expectedLinks = {
+        self: '/v2/toppings',
+        first: '/v2/toppings?page[number]=1',
+        last: '/v2/toppings?page[number]=1',
+        next: null,
+        prev: null
+      };
+
+      request(app(this.options))
+        .get('/v2/toppings')
+        .expect(validators.basicValidation)
+        .expect(validators.assertData(expectedData))
+        .expect(validators.assertLinks(expectedLinks))
+        .expect(200)
+        .end(done);
+    });
+  });
+});

--- a/test/integration/get-many-resource/many-to-many/host.js
+++ b/test/integration/get-many-resource/many-to-many/host.js
@@ -1,0 +1,143 @@
+const path = require('path');
+const request = require('supertest');
+const app = require('../../../../server/app');
+const getDb = require('../../../../lib/database');
+const wipeDatabase = require('../../../../lib/database/wipe');
+const validators = require('../../../helpers/json-api-validators');
+const applyMigrations = require('../../../helpers/apply-migrations');
+const seed = require('../../../helpers/seed');
+
+const db = getDb();
+
+describe('Resource GET (many) many-to-many (host)', function() {
+  // Ensure that the DB connection drops immediately after each test
+  afterEach(() => {
+    db.$config.pgp.end();
+  });
+
+  // Ensure that there's no lingering data between tests by wiping the
+  // database before each test.
+  beforeEach(done => {
+    wipeDatabase(db).then(() => done());
+  });
+
+  describe('when the request succeeds', () => {
+    beforeEach((done) => {
+      this.options = {
+        resourcesDirectory: path.join(global.fixturesDirectory, 'many-to-many'),
+        apiVersion: 2
+      };
+
+      const toppingSeeds = [
+        {name: 'cheese'},
+        {name: 'marinara'},
+        {name: 'pepperoni'}
+      ];
+
+      const pizzaSeeds = [
+        {name: 'cheese', size: 'small'},
+        {name: 'pepperoni', size: '3'},
+        {name: 'white', size: '1'}
+      ];
+
+      const pizzaToppingSeeds = [
+        // Cheese pizza: cheese, marinara
+        {pizza_id: '1', topping_id: '1'},
+        {pizza_id: '1', topping_id: '2'},
+        // pepperoni pizza: cheese, marinara, pepperoni
+        {pizza_id: '2', topping_id: '1'},
+        {pizza_id: '2', topping_id: '2'},
+        {pizza_id: '2', topping_id: '3'},
+        // white pizza: cheese
+        {pizza_id: '3', topping_id: '1'},
+      ];
+
+      applyMigrations(this.options)
+        .then(() => seed('topping', toppingSeeds))
+        .then(() => seed('pizza', pizzaSeeds))
+        .then(() => seed('pizza_topping', pizzaToppingSeeds))
+        .then(() => done());
+    });
+
+    it('should return a 200 OK, with the resource and its related items', (done) => {
+      const expectedData = [
+        {
+          type: 'pizzas',
+          id: '1',
+          attributes: {
+            name: 'cheese',
+            size: 'small'
+          },
+          relationships: {
+            toppings: {
+              data: [
+                {id: '1', type: 'toppings'},
+                {id: '2', type: 'toppings'},
+              ],
+              links: {
+                self: '/v2/pizzas/1/relationships/toppings',
+                related: '/v2/pizzas/1/toppings'
+              }
+            }
+          }
+        },
+        {
+          type: 'pizzas',
+          id: '2',
+          attributes: {
+            name: 'pepperoni',
+            size: '3'
+          },
+          relationships: {
+            toppings: {
+              data: [
+                {id: '1', type: 'toppings'},
+                {id: '2', type: 'toppings'},
+                {id: '3', type: 'toppings'},
+              ],
+              links: {
+                self: '/v2/pizzas/2/relationships/toppings',
+                related: '/v2/pizzas/2/toppings'
+              }
+            }
+          }
+        },
+        {
+          type: 'pizzas',
+          id: '3',
+          attributes: {
+            name: 'white',
+            size: '1'
+          },
+          relationships: {
+            toppings: {
+              data: [
+                {id: '1', type: 'toppings'},
+              ],
+              links: {
+                self: '/v2/pizzas/3/relationships/toppings',
+                related: '/v2/pizzas/3/toppings'
+              }
+            }
+          }
+        }
+      ];
+
+      const expectedLinks = {
+        self: '/v2/pizzas',
+        first: '/v2/pizzas?page[number]=1',
+        last: '/v2/pizzas?page[number]=1',
+        next: null,
+        prev: null
+      };
+
+      request(app(this.options))
+        .get('/v2/pizzas')
+        .expect(validators.basicValidation)
+        .expect(validators.assertData(expectedData))
+        .expect(validators.assertLinks(expectedLinks))
+        .expect(200)
+        .end(done);
+    });
+  });
+});

--- a/test/integration/get-one-resource/many-to-many/guest.js
+++ b/test/integration/get-one-resource/many-to-many/guest.js
@@ -1,0 +1,96 @@
+const path = require('path');
+const request = require('supertest');
+const app = require('../../../../server/app');
+const getDb = require('../../../../lib/database');
+const wipeDatabase = require('../../../../lib/database/wipe');
+const validators = require('../../../helpers/json-api-validators');
+const applyMigrations = require('../../../helpers/apply-migrations');
+const seed = require('../../../helpers/seed');
+
+const db = getDb();
+
+describe('Resource GET (one) many-to-many (guest)', function() {
+  // Ensure that the DB connection drops immediately after each test
+  afterEach(() => {
+    db.$config.pgp.end();
+  });
+
+  // Ensure that there's no lingering data between tests by wiping the
+  // database before each test.
+  beforeEach(done => {
+    wipeDatabase(db).then(() => done());
+  });
+
+  describe('when the request succeeds', () => {
+    beforeEach((done) => {
+      this.options = {
+        resourcesDirectory: path.join(global.fixturesDirectory, 'many-to-many'),
+        apiVersion: 2
+      };
+
+      const toppingSeeds = [
+        {name: 'cheese'},
+        {name: 'marinara'},
+        {name: 'pepperoni'}
+      ];
+
+      const pizzaSeeds = [
+        {name: 'cheese', size: 'small'},
+        {name: 'pepperoni', size: '3'},
+        {name: 'white', size: '1'}
+      ];
+
+      const pizzaToppingSeeds = [
+        // Cheese pizza: cheese, marinara
+        {pizza_id: '1', topping_id: '1'},
+        {pizza_id: '1', topping_id: '2'},
+        // pepperoni pizza: cheese, marinara, pepperoni
+        {pizza_id: '2', topping_id: '1'},
+        {pizza_id: '2', topping_id: '2'},
+        {pizza_id: '2', topping_id: '3'},
+        // white pizza: cheese
+        {pizza_id: '3', topping_id: '1'},
+      ];
+
+      applyMigrations(this.options)
+        .then(() => seed('topping', toppingSeeds))
+        .then(() => seed('pizza', pizzaSeeds))
+        .then(() => seed('pizza_topping', pizzaToppingSeeds))
+        .then(() => done());
+    });
+
+    it.only('should return a 200 OK, with the resource and its related items', (done) => {
+      const expectedData = {
+        type: 'toppings',
+        id: '2',
+        attributes: {
+          name: 'marinara'
+        },
+        relationships: {
+          pizzas: {
+            data: [
+              {id: '1', type: 'pizzas'},
+              {id: '2', type: 'pizzas'},
+            ],
+            links: {
+              self: '/v2/toppings/2/relationships/pizzas',
+              related: '/v2/toppings/2/pizzas'
+            }
+          }
+        }
+      };
+
+      const expectedLinks = {
+        self: '/v2/toppings/2',
+      };
+
+      request(app(this.options))
+        .get('/v2/toppings/2')
+        .expect(validators.basicValidation)
+        .expect(validators.assertData(expectedData))
+        .expect(validators.assertLinks(expectedLinks))
+        .expect(200)
+        .end(done);
+    });
+  });
+});

--- a/test/integration/get-one-resource/many-to-many/host.js
+++ b/test/integration/get-one-resource/many-to-many/host.js
@@ -9,7 +9,7 @@ const seed = require('../../../helpers/seed');
 
 const db = getDb();
 
-describe('Resource GET (one) many-to-many (guest)', function() {
+describe('Resource GET (one) many-to-many (host)', function() {
   // Ensure that the DB connection drops immediately after each test
   afterEach(() => {
     db.$config.pgp.end();
@@ -61,31 +61,32 @@ describe('Resource GET (one) many-to-many (guest)', function() {
 
     it('should return a 200 OK, with the resource and its related items', (done) => {
       const expectedData = {
-        type: 'toppings',
-        id: '2',
+        type: 'pizzas',
+        id: '1',
         attributes: {
-          name: 'marinara'
+          name: 'cheese',
+          size: 'small'
         },
         relationships: {
-          pizzas: {
+          toppings: {
             data: [
-              {id: '1', type: 'pizzas'},
-              {id: '2', type: 'pizzas'},
+              {id: '1', type: 'toppings'},
+              {id: '2', type: 'toppings'},
             ],
             links: {
-              self: '/v2/toppings/2/relationships/pizzas',
-              related: '/v2/toppings/2/pizzas'
+              self: '/v2/pizzas/1/relationships/toppings',
+              related: '/v2/pizzas/1/toppings'
             }
           }
         }
       };
 
       const expectedLinks = {
-        self: '/v2/toppings/2',
+        self: '/v2/pizzas/1',
       };
 
       request(app(this.options))
-        .get('/v2/toppings/2')
+        .get('/v2/pizzas/1')
         .expect(validators.basicValidation)
         .expect(validators.assertData(expectedData))
         .expect(validators.assertLinks(expectedLinks))


### PR DESCRIPTION
This code continues the pretty bad implementation of relationships I've got going right now, but I can see a clear path to refactor once I get some basic tests down.

This adds read-one support for m-n guest relationships. Todo:

- [x] add host support
- [x] add read many support

---

This is pretty nice, as it completes the reads for all relationship types. Once the reads are done, I can go in and start refactoring, or begin work on the writes.

As part of #201 