### PR TITLE
Store related definition directly on relationship definition

### DIFF
--- a/lib/resource-definition/generate.js
+++ b/lib/resource-definition/generate.js
@@ -32,7 +32,9 @@ function mapObjToArray(obj, key = 'name') {
 
 // Maps a Model to its Definition
 function generateDefinition(model) {
-  const arrayRelationships = mapObjToArray(model.relationships);
+  const relationships = _.cloneDeep(model.relationships);
+  const arrayRelationships = mapObjToArray(relationships);
+
   const hostRelationships = _.filter(arrayRelationships, 'host');
   const guestRelationships = _.reject(arrayRelationships, 'host');
 
@@ -89,17 +91,10 @@ module.exports = function(resourceModels) {
   // based on their relationships. This will help us build queries that involve
   // relationships.
   return _.map(baseDefinition, (definition, index, definitions) => {
-    // Find all of the resources that this resource is related to, and put them
-    // into an array.
-    const definitionsInRelationships = _.chain(definition.relationships)
-      .map((relationship) => {
-        return _.find(definitions, {name: relationship.resource});
-      })
-      // A resource may have multiple relationships with another resource. Remove
-      // duplicates from this array, since one reference is all we need here.
-      .uniq()
-      .value();
+    _.forEach(definition.relationships, r => {
+      r.relatedDefinition = _.find(definitions, {name: r.resource});
+    });
 
-    return Object.assign(definition, {definitionsInRelationships});
+    return definition;
   });
 };

--- a/lib/sql/crud.js
+++ b/lib/sql/crud.js
@@ -33,7 +33,7 @@ exports.read = function({definition, fields, db, id, pageSize, pageNumber, enabl
 
   const escaped = {escaped: true};
   let withClauses = _.map(definition.externallyStoredRelationships, relationship => {
-    const otherResource = _.find(definition.definitionsInRelationships, {name: relationship.resource});
+    const otherResource = relationship.relatedDefinition;
     const otherRelationship = _.find(otherResource.relationships, {resource: definition.name});
 
     const selfTableName = sqlUtil.getTableName(definition, escaped);

--- a/lib/sql/many-to-many-util.js
+++ b/lib/sql/many-to-many-util.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const pgp = require('pg-promise');
 const sqlUtil = require('./sql-util');
 
@@ -29,8 +28,8 @@ function getPrimaryKeyColumnName({host, guest, escaped}) {
   return escaped ? pgp.as.name(rawName) : rawName;
 }
 
-function buildAssociativeTable({relationship, definition, definitions}) {
-  const guest = _.find(definitions, {name: relationship.resource});
+function buildAssociativeTable({relationship, definition}) {
+  const guest = relationship.relatedDefinition;
   const host = definition;
 
   const tableName = getAssociativeTableName({host, guest, escaped: true});

--- a/server/util/build-response-relationships.js
+++ b/server/util/build-response-relationships.js
@@ -80,7 +80,7 @@ function findHostedRelationships(result, definition, version) {
 
 function findAssociatedRelationships(result, definition, version) {
   return _.reduce(definition.relationshipsInAssociativeTable, (memo, relation) => {
-    const otherResource = _.find(definition.definitionsInRelationships, {name: relation.resource});
+    const otherResource = relation.relatedDefinition;
     const columnBase = adjustResourceQuantity.getPluralName(relation.resource);
     let columnName;
     if (!relation.host) {


### PR DESCRIPTION
This is the teeniest step toward making the relationship code less gross. It stores the related definition directly on the relationship.

Other things should be stored, as well, like SQL names.