### PR TITLE
Move wipe-database SQL file into sql directory

### DIFF
--- a/lib/database/wipe.js
+++ b/lib/database/wipe.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const wipeDb = `DROP SCHEMA public CASCADE;
-  CREATE SCHEMA public;
-  GRANT ALL ON SCHEMA public TO postgres;
-  GRANT ALL ON SCHEMA public TO public;
-  COMMENT ON SCHEMA public IS 'standard public schema';`;
+const fs = require('fs');
+const path = require('path');
+
+const wipeDbPath = path.join(__dirname, '..', 'sql', 'wipe-database.sql');
+const wipeDb = fs.readFileSync(wipeDbPath, 'utf-8');
 
 // Wipes the database.
 // Returns a Promise that resolves if the wipe succeeds, and rejects if it

--- a/lib/sql/wipe-database.sql
+++ b/lib/sql/wipe-database.sql
@@ -1,0 +1,5 @@
+DROP SCHEMA public CASCADE;
+  CREATE SCHEMA public;
+  GRANT ALL ON SCHEMA public TO postgres;
+  GRANT ALL ON SCHEMA public TO public;
+  COMMENT ON SCHEMA public IS 'standard public schema';


### PR DESCRIPTION
This consolidates all files that generate or contain SQL into one place. It's a first step to supporting adapters.

One day, this won't wipe the public schema, but instead, just the api-pls one ( #188 )