### PR TITLE
Convert write middlewares to use transactions

### DIFF
--- a/server/resource/middleware/delete.js
+++ b/server/resource/middleware/delete.js
@@ -15,7 +15,11 @@ module.exports = async function(req, res) {
 
   log.info({query, resourceName: this.definition.name, reqId: req.id}, 'Deleting a resource');
 
-  const result = await this.db.one(query).catch(r => r);
+  const result = await this.db.tx(t => {
+    const primaryTableQuery = t.one(query);
+    return t.batch([primaryTableQuery]);
+  }).catch(r => r);
+
   if (_.isError(result)) {
     return handleQueryError({
       err: result,


### PR DESCRIPTION
Writing to external relationships will require modifications to
other tables. In Postgres, you cannot update more than one table
at a time. Therefore, using a transaction is necessary.

---

The next step here is to generate the correct queries to update the other relationships.